### PR TITLE
Follow comments, split non-list objects

### DIFF
--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -210,6 +210,7 @@ class LookupModule(LookupBase):
 
     def process_list(self, field_name, rule, valid_list, rule_number):
         return_values = []
+        # If its not a list, we need to split it into a list
         if not isinstance(rule[field_name], list):
             rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:

--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -196,7 +196,7 @@ class LookupModule(LookupBase):
         if isinstance(rule[field_name], int):
             rule[field_name] = [rule[field_name]]
         # If its not a list, we need to split it into a list
-        if isinstance(rule[field_name], list):
+        if not isinstance(rule[field_name], list):
             rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
             # If they have a list of strs we want to strip the str incase its space delineated
@@ -210,7 +210,8 @@ class LookupModule(LookupBase):
 
     def process_list(self, field_name, rule, valid_list, rule_number):
         return_values = []
-        rule[field_name] = rule[field_name].split(',')
+        if not isinstance(rule[field_name], list):
+            rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
             value = value.strip()
             if value not in valid_list:


### PR DESCRIPTION
##### SUMMARY
This is a change on top of another change, but keeps the added tests from that.

If we get an object that is not a list, we split in order to make it a list. The original bug seems to be that it had it the wrong way around.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

